### PR TITLE
Cherry pick fix for Python 3 (3.6)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -8,13 +8,13 @@ Version strings conform to the `Semantic Versioning`_ specification,
 ..  _Semantic Versioning: https://semver.org/
 
 
-Version NEXT
-============
+Version 2.2.4.1
+================
 
-:Released: FUTURE
-:Maintainer: UNKNOWN <unknown@example.org>
+:Released: 2020-05-11
+:Maintainer: Richard Offer <richard@whitequeen.com>
 
-No changes.
+Merge PR to fix working on Python3.6
 
 
 Version 2.2.4

--- a/daemon/runner.py
+++ b/daemon/runner.py
@@ -131,8 +131,12 @@ class DaemonRunner:
             """
         self.daemon_context.stdin = open(app.stdin_path, 'rt')
         self.daemon_context.stdout = open(app.stdout_path, 'w+t')
-        self.daemon_context.stderr = open(
+        try:
+            self.daemon_context.stderr = open(
                 app.stderr_path, 'w+t', buffering=0)
+        except ValueError:
+            self.daemon_context.stderr = open(
+                app.stderr_path, 'w+b', buffering=0)
 
     def _usage_exit(self, argv):
         """ Emit a usage message, then exit.


### PR DESCRIPTION
Pulled from https://pagure.io/fork/earthgecko/python-daemon/c/e5690373d020cf613afeb506b78c3d3dd8b8f000?branch=py3_unbuffered_bytes_io